### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Installation
 
-The preferred method of including the Stretchr SDK in your project is through [Cocoapods](http://cocoapods.org/). To install Cocoapods, simply do:
+The preferred method of including the Stretchr SDK in your project is through [CocoaPods](http://cocoapods.org/). To install CocoaPods, simply do:
 
 `sudo gem install cocoapods`
 
-Once Cocoapods is installed, you need to add the Stretchr SDK to your Podfile. For example, in your project directory:
+Once CocoaPods is installed, you need to add the Stretchr SDK to your Podfile. For example, in your project directory:
 
 `vi Podfile`
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
